### PR TITLE
chore(templates): Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,59 @@
+name: '🐞 Bug Report'
+description: Create a report to help us improve
+labels: ['type: bug', 'status: unconfirmed']
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # 🐞 Bug Report
+
+        Thank you for taking the time to make this project better by reporting a bug!
+
+        Please fill out the following sections with as much detail as you can.
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Be as descriptive as possible. Feel free to include screenshots, logs, or code snippets.
+    validations:
+      required: true
+
+  - type: input
+    id: reproduction-link
+    attributes:
+      label: Reproduction link
+      description: A link to a reproduction repository or a minimal code snippet that demonstrates the bug (Github repository, CodeSandbox, etc.)
+      placeholder: 'https://github.com/username/repository-name'
+
+  - type: textarea
+    id: expected-result
+    attributes:
+      label: Expected result
+      description: A clear and concise description of what you expected to happen.
+      placeholder: 'I expected to see ...'
+
+  - type: textarea
+    id: actual-result
+    attributes:
+      label: Actual result
+      description: A clear and concise description of what actually happened.
+      placeholder: 'Instead, I saw ...'
+
+  - type: textarea
+    id: other-information
+    attributes:
+      label: Other information
+      description: |
+        Any other information that you think is relevant to the bug report. This might include the lines of code that you have identified as causing the bug, and potential solutions (and your opinions on their merits).
+      placeholder: |
+        I think this might be caused by...
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Final checks
+      options:
+        - label: I have provided steps to reproduce the issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,42 @@
+name: '🚀 Feature request'
+description: Suggest an idea for improving
+labels: 'type: enhancement'
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # 🚀 Feature request
+        Thanks for taking the time to fill out this feature request!
+
+        Please fill out as much of the template below as you can. If you're unsure whether the feature request is relevant, feel free to create an issue anyway. We'll figure it out together.
+
+  - type: textarea
+    attributes:
+      label: 'Is your feature request related to a problem? Please describe.'
+      description: 'A clear and concise description of what the problem is.'
+      placeholder: "I'm always frustrated when [...]"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: "Describe the solution you'd like"
+      description: 'A clear and concise description of what you want to happen.'
+      placeholder: 'I would like to see [...]'
+
+  - type: textarea
+    attributes:
+      label: "Describe alternatives you've considered"
+      description: "A clear and concise description of any alternative solutions or features you've considered."
+      placeholder: 'I have considered [...]'
+
+  - type: textarea
+    attributes:
+      label: 'Additional context'
+      description: 'Add any other context or screenshots about the feature request here.'
+      placeholder: 'Be as descriptive as possible. Consider attaching screenshots or links to other issues.'
+
+  - type: textarea
+    attributes:
+      label: 'Other solutions you have considered'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,58 @@
+&lt;!---
+
+## Summary
+
+Provide a short summary here. Examples of good PR titles:
+
+- "feat: add so-and-so models"
+
+- "fix: deduplicate such-and-such"
+
+- "Update: dbt version 0.13.0"
+
+-->
+
+## Description & motivation
+
+&lt;!---
+
+Describe your changes, and why you're making them. Is this linked to an open
+
+issue or another pull request? Link it here.
+
+Example:
+Issue: #123
+
+-->
+
+## To-do before merge
+
+&lt;!---
+
+(Optional -- remove this section if not needed)
+
+Include any notes about things that need to happen before this PR is merged, e.g.:
+
+- [ ] Change the base branch
+
+-->
+
+## Checklist:
+
+&lt;!---
+
+This checklist is mostly useful as a reminder of small things that can easily be
+
+forgotten – it is meant as a helpful tool rather than hoops to jump through.
+
+Put an `x` in all the items that apply, make notes next to any that haven't been
+
+addressed, and remove any items that are not relevant to this PR.
+
+-->
+
+- [ ] My pull request represents one logical piece of work.
+
+- [ ] My commits are related to the pull request and look clean.
+
+- [ ] I have added appropriate tests and documentation to any new models.


### PR DESCRIPTION
This commit adds issue and PR templates to the repository. This will help us to get more information about the issue or PR and also help the contributor to provide the required information.

The issue templates currently have two options:
- Bug report
- Feature request